### PR TITLE
Corrects .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ hs_err_pid*
 
 *.iml
 .gradle
-/local.properties
+local.properties
 /.idea/workspace.xml
 /.idea/libraries
 .DS_Store


### PR DESCRIPTION
having local.properties pushed onto git causes problems as it contains information local to your machine. This would cause the app to not compile or even find the sdk.